### PR TITLE
discovery client setup complete

### DIFF
--- a/src/main/java/com/addressservice/AddressServiceApplication.java
+++ b/src/main/java/com/addressservice/AddressServiceApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 public class AddressServiceApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
address-service is setup as a discovery client successfully now address-service instances could be monitored from discovery client or the service-registry app. 